### PR TITLE
Exit testing with pytest return code

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+
+import sys
+
 import setuptools
 from setuptools import setup
 from setuptools.command.test import test as TestCommand
@@ -17,7 +20,7 @@ class PyTest(TestCommand):
 
     def run_tests(self):
         import pytest
-        pytest.main(self.test_args)
+        sys.exit(pytest.main(self.test_args))
 
 
 with open("README.rst") as readme_file:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4,4 +4,5 @@
 from __future__ import absolute_import
 
 
-from dask_ndmorph import core
+def test_import_core():
+    from dask_ndmorph import core


### PR DESCRIPTION
Make sure that we use `pytest.main`'s return code as the exit code. This way test failure from `python setup.py test` results in a non-zero exit code.