### PR TITLE
Fix import of incorrectly named module

### DIFF
--- a/dask_ndmorph/__init__.py
+++ b/dask_ndmorph/__init__.py
@@ -7,4 +7,4 @@ from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
 
-from dask_ndfilters.core import *
+from dask_ndmorph.core import *


### PR DESCRIPTION
Was accidentally made `dask_ndfilters` in PR ( https://github.com/dask-image/dask-ndmorph/pull/7 )  when it should have been named `dask_ndmorph` instead.