### PR TITLE
Add _utils

### DIFF
--- a/dask_ndmorph/_utils.py
+++ b/dask_ndmorph/_utils.py
@@ -6,6 +6,8 @@ import inspect
 import numbers
 import re
 
+import numpy
+
 
 try:
     from itertools import imap, izip
@@ -111,3 +113,25 @@ def _get_depth_boundary(ndim, depth, boundary=None):
             boundary[i] = "reflect"
 
     return depth, boundary
+
+
+def _get_size(ndim, size):
+    if not isinstance(ndim, numbers.Integral):
+        raise TypeError("The ndim must be of integral type.")
+
+    if isinstance(size, numbers.Number):
+        size = ndim * (size,)
+    size = numpy.array(size)
+
+    if size.ndim != 1:
+        raise RuntimeError("The size must have only one dimension.")
+    if len(size) != ndim:
+        raise RuntimeError(
+            "The size must have a length equal to the number of dimensions."
+        )
+    if not issubclass(size.dtype.type, numbers.Integral):
+        raise TypeError("The size must be of integral type.")
+
+    size = tuple(size)
+
+    return size

--- a/dask_ndmorph/_utils.py
+++ b/dask_ndmorph/_utils.py
@@ -135,3 +135,45 @@ def _get_size(ndim, size):
     size = tuple(size)
 
     return size
+
+
+def _get_origin(size, origin=0):
+    size = numpy.array(size)
+    ndim = len(size)
+
+    if isinstance(origin, numbers.Number):
+        origin = ndim * (origin,)
+
+    origin = numpy.array(origin)
+
+    if not issubclass(origin.dtype.type, numbers.Integral):
+        raise TypeError("The origin must be of integral type.")
+
+    # Validate dimensions.
+    if origin.ndim != 1:
+        raise RuntimeError("The origin must have only one dimension.")
+    if len(origin) != ndim:
+        raise RuntimeError(
+            "The origin must have the same length as the number of dimensions"
+            " as the array being filtered."
+        )
+
+    # Validate origin is bounded.
+    if not (origin < ((size + 1) // 2)).all():
+        raise ValueError("The origin must be within the footprint.")
+
+    origin = tuple(origin)
+
+    return origin
+
+
+def _get_depth(size, origin=0):
+    origin = numpy.array(_get_origin(size, origin))
+    size = numpy.array(size)
+
+    half_size = size // 2
+    depth = half_size + abs(origin)
+
+    depth = tuple(depth)
+
+    return depth

--- a/dask_ndmorph/_utils.py
+++ b/dask_ndmorph/_utils.py
@@ -87,6 +87,8 @@ def _get_depth_boundary(ndim, depth, boundary=None):
     if not all(map(lambda d: d >= 0, depth.values())):
         raise ValueError("Expected positive semidefinite values for `depth`.")
 
+    depth = dict([(a, int(d)) for a, d in depth.items()])
+
     if (boundary is None) or isinstance(boundary, strlike):
         boundary = ndim * (boundary,)
     if not isinstance(boundary, collections.Sized):

--- a/dask_ndmorph/_utils.py
+++ b/dask_ndmorph/_utils.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+
+
+import collections
+import inspect
+import numbers
+import re
+
+
+try:
+    from itertools import imap, izip
+except ImportError:
+    imap, izip = map, zip
+
+try:
+    irange = xrange
+except NameError:
+    irange = range
+
+try:
+    unicode
+except NameError:
+    unicode = str
+
+strlike = (bytes, unicode)
+
+
+def _get_docstring(func):
+    # Drop the output parameter from the docstring.
+    split_doc_params = lambda s: \
+        re.subn("(    [A-Za-z]+ : )", "\0\\1", s)[0].split("\0")
+    drop_doc_param = lambda s: not s.startswith("    output : ")
+    func_doc = "" if func.__doc__ is None else func.__doc__
+    cleaned_docstring = "".join([
+        l for l in split_doc_params(func_doc) if drop_doc_param(l)
+    ])
+
+    docstring = """
+    Wrapped copy of "{mod_name}.{func_name}"
+
+
+    Excludes the output parameter as it would not work Dask arrays.
+
+
+    Original docstring:
+
+    {doc}
+    """.format(
+        mod_name=inspect.getmodule(func).__name__,
+        func_name=func.__name__,
+        doc=cleaned_docstring,
+    )
+
+    return docstring
+
+
+def _update_wrapper(func):
+    def _updater(wrapper):
+        wrapper.__name__ = func.__name__
+        wrapper.__doc__ = _get_docstring(func)
+        return wrapper
+
+    return _updater
+
+
+def _get_depth_boundary(ndim, depth, boundary=None):
+    if not isinstance(ndim, numbers.Integral):
+        raise TypeError("Expected integer value for `ndim`.")
+    if ndim <= 0:
+        raise ValueError("Expected positive value for `ndim`.")
+
+    if isinstance(depth, numbers.Number):
+        depth = ndim * (depth,)
+    if not isinstance(depth, collections.Sized):
+        raise TypeError("Unexpected type for `depth`.")
+    if len(depth) != ndim:
+        raise ValueError("Expected `depth` to have a length equal to `ndim`.")
+    if isinstance(depth, collections.Sequence):
+        depth = dict(izip(irange(ndim), depth))
+    if not isinstance(depth, collections.Mapping):
+        raise TypeError("Unexpected type for `depth`.")
+
+    if not all(map(lambda d: isinstance(d, numbers.Integral), depth.values())):
+        raise TypeError("Expected integer values for `depth`.")
+    if not all(map(lambda d: d >= 0, depth.values())):
+        raise ValueError("Expected positive semidefinite values for `depth`.")
+
+    if (boundary is None) or isinstance(boundary, strlike):
+        boundary = ndim * (boundary,)
+    if not isinstance(boundary, collections.Sized):
+        raise TypeError("Unexpected type for `boundary`.")
+    if len(boundary) != ndim:
+        raise ValueError(
+            "Expected `boundary` to have a length equal to `ndim`."
+        )
+    if isinstance(boundary, collections.Sequence):
+        boundary = dict(izip(irange(ndim), boundary))
+    if not isinstance(boundary, collections.Mapping):
+        raise TypeError("Unexpected type for `boundary`.")
+
+    type_check = lambda b: (b is None) or isinstance(b, strlike)
+    if not all(map(type_check, boundary.values())):
+        raise TypeError("Expected string-like values for `boundary`.")
+
+    # Workaround for a bug in Dask with 0 depth.
+    #
+    # ref: https://github.com/dask/dask/issues/2258
+    #
+    for i in irange(ndim):
+        if boundary[i] == "none" and depth[i] == 0:
+            boundary[i] = "reflect"
+
+    return depth, boundary

--- a/dask_ndmorph/_utils.py
+++ b/dask_ndmorph/_utils.py
@@ -39,7 +39,7 @@ def _get_docstring(func):
     Wrapped copy of "{mod_name}.{func_name}"
 
 
-    Excludes the output parameter as it would not work Dask arrays.
+    Excludes the output parameter as it would not work with Dask arrays.
 
 
     Original docstring:

--- a/dask_ndmorph/_utils.py
+++ b/dask_ndmorph/_utils.py
@@ -177,3 +177,30 @@ def _get_depth(size, origin=0):
     depth = tuple(depth)
 
     return depth
+
+
+def _get_footprint(ndim, size=None, footprint=None):
+    # Verify that we only got size or footprint.
+    if size is None and footprint is None:
+        raise RuntimeError("Must provide either size or footprint.")
+    if size is not None and footprint is not None:
+        raise RuntimeError("Provide either size or footprint, but not both.")
+
+    # Get a footprint based on the size.
+    if size is not None:
+        size = _get_size(ndim, size)
+        footprint = numpy.ones(size, dtype=bool)
+
+    # Validate the footprint.
+    if footprint.ndim != ndim:
+        raise RuntimeError(
+            "The footprint must have the same number of dimensions as"
+            " the array being filtered."
+        )
+    if footprint.size == 0:
+        raise RuntimeError("The footprint must have only non-zero dimensions.")
+
+    # Convert to Boolean.
+    footprint = (footprint != 0)
+
+    return footprint

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -19,7 +19,7 @@ def test__get_docstring():
     Wrapped copy of "{mod_name}.{func_name}"
 
 
-    Excludes the output parameter as it would not work Dask arrays.
+    Excludes the output parameter as it would not work with Dask arrays.
 
 
     Original docstring:
@@ -48,7 +48,7 @@ def test__update_wrapper():
     Wrapped copy of "{mod_name}.{func_name}"
 
 
-    Excludes the output parameter as it would not work Dask arrays.
+    Excludes the output parameter as it would not work with Dask arrays.
 
 
     Original docstring:

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -85,3 +85,18 @@ def test__update_wrapper():
 def test_errs__get_depth_boundary(err_type, ndim, depth, boundary):
     with pytest.raises(err_type):
         _utils._get_depth_boundary(ndim, depth, boundary)
+
+
+@pytest.mark.parametrize(
+    "err_type, ndim, size",
+    [
+        (TypeError, 1.0, 1),
+        (RuntimeError, 1, [[1]]),
+        (TypeError, 1, 1.0),
+        (TypeError, 1, [1.0]),
+        (RuntimeError, 1, [1, 1]),
+    ]
+)
+def test_errs__get_size(err_type, ndim, size):
+    with pytest.raises(err_type):
+        _utils._get_size(ndim, size)

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -9,7 +9,7 @@ import pytest
 
 import numpy
 
-from dask_ndfilters import _utils
+from dask_ndmorph import _utils
 
 
 def test__get_docstring():

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -7,6 +7,8 @@ import inspect
 
 import pytest
 
+import numpy
+
 from dask_ndfilters import _utils
 
 
@@ -100,3 +102,93 @@ def test_errs__get_depth_boundary(err_type, ndim, depth, boundary):
 def test_errs__get_size(err_type, ndim, size):
     with pytest.raises(err_type):
         _utils._get_size(ndim, size)
+
+
+@pytest.mark.parametrize(
+    "err_type, size, origin",
+    [
+        (TypeError, [1], 1.0),
+        (TypeError, [1], [1.0]),
+        (RuntimeError, [1], [[1]]),
+        (RuntimeError, [1], [1, 1]),
+        (ValueError, [1], [2]),
+    ]
+)
+def test_errs__get_origin(err_type, size, origin):
+    with pytest.raises(err_type):
+        _utils._get_origin(size, origin)
+
+
+@pytest.mark.parametrize(
+    "err_type, ndim, size, footprint",
+    [
+        (RuntimeError, 1, None, None),
+        (RuntimeError, 1, [2], numpy.ones((2,), dtype=bool)),
+        (RuntimeError, 1, None, numpy.ones((1, 2), dtype=bool)),
+        (RuntimeError, 1, None, numpy.ones([0], dtype=bool)),
+    ]
+)
+def test_errs__get_footprint(err_type, ndim, size, footprint):
+    with pytest.raises(err_type):
+        _utils._get_footprint(ndim, size=size, footprint=footprint)
+
+
+@pytest.mark.parametrize(
+    "expected, ndim, depth, boundary",
+    [
+        (({0: 0}, {0: "reflect"}), 1, 0, "none"),
+        (({0: 0}, {0: "reflect"}), 1, 0, "reflect"),
+        (({0: 0}, {0: "periodic"}), 1, 0, "periodic"),
+        (({0: 1}, {0: "none"}), 1, 1, "none"),
+    ]
+)
+def test__get_depth_boundary(expected, ndim, depth, boundary):
+    assert expected == _utils._get_depth_boundary(ndim, depth, boundary)
+
+
+@pytest.mark.parametrize(
+    "expected, ndim, size",
+    [
+        ((1,), 1, 1),
+        ((3, 3), 2, 3),
+        ((2, 4), 2, (2, 4)),
+    ]
+)
+def test__get_size(expected, ndim, size):
+    assert expected == _utils._get_size(ndim, size)
+
+
+@pytest.mark.parametrize(
+    "expected, size, origin",
+    [
+        ((0,), (1,), 0),
+        ((1,), (3,), 1),
+        ((1, 2), (3, 5), (1, 2)),
+    ]
+)
+def test__get_origin(expected, size, origin):
+    assert expected == _utils._get_origin(size, origin)
+
+
+@pytest.mark.parametrize(
+    "expected, size, origin",
+    [
+        ((0,), (1,), 0),
+        ((1,), (3,), 0),
+        ((2,), (3,), 1),
+        ((2, 4), (3, 5), (1, 2)),
+    ]
+)
+def test__get_depth(expected, size, origin):
+    assert expected == _utils._get_depth(size, origin)
+
+
+@pytest.mark.parametrize(
+    "expected, ndim, size, footprint",
+    [
+        (numpy.ones((2,), dtype=bool), 1, 2, None),
+        (numpy.ones((2,), dtype=bool), 1, None, numpy.ones((2,), dtype=bool)),
+    ]
+)
+def test__get_footprint(expected, ndim, size, footprint):
+    assert (expected == _utils._get_footprint(ndim, size, footprint)).all()

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+
+import inspect
+
+import pytest
+
+from dask_ndfilters import _utils
+
+
+def test__get_docstring():
+    f = lambda : 0
+
+    result = _utils._get_docstring(f)
+
+    expected = """
+    Wrapped copy of "{mod_name}.{func_name}"
+
+
+    Excludes the output parameter as it would not work Dask arrays.
+
+
+    Original docstring:
+
+    {doc}
+    """.format(
+        mod_name=inspect.getmodule(f).__name__,
+        func_name=f.__name__,
+        doc="",
+    )
+
+    assert result == expected
+
+
+def test__update_wrapper():
+    f = lambda : 0
+
+    @_utils._update_wrapper(f)
+    def g():
+        return f()
+
+
+    assert f.__name__ == g.__name__
+
+    expected = """
+    Wrapped copy of "{mod_name}.{func_name}"
+
+
+    Excludes the output parameter as it would not work Dask arrays.
+
+
+    Original docstring:
+
+    {doc}
+    """.format(
+        mod_name=inspect.getmodule(g).__name__,
+        func_name=g.__name__,
+        doc="",
+    )
+
+    assert g.__doc__ == expected
+
+
+@pytest.mark.parametrize(
+    "err_type, ndim, depth, boundary",
+    [
+        (TypeError, lambda : 0, 1, None),
+        (TypeError, 1.0, 1, None),
+        (ValueError, -1, 1, None),
+        (TypeError, 1, lambda : 0, None),
+        (TypeError, 1, 1.0, None),
+        (ValueError, 1, -1, None),
+        (ValueError, 1, (1, 1), None),
+        (ValueError, 1, {0: 1, 1: 1}, None),
+        (TypeError, 1, {1}, None),
+        (TypeError, 1, 1, 1),
+        (ValueError, 1, 1, (None, None)),
+        (ValueError, 1, 1, {0: None, 1: None}),
+        (TypeError, 1, 1, (1,)),
+        (TypeError, 1, 1, {1}),
+    ]
+)
+def test_errs__get_depth_boundary(err_type, ndim, depth, boundary):
+    with pytest.raises(err_type):
+        _utils._get_depth_boundary(ndim, depth, boundary)


### PR DESCRIPTION
Adds a private utility module used to hold common wrapping functions.

Borrows nearly all of its content from `dask-ndfilters`. Includes references for all content pulled in from `dask-ndfilters`. A little bit of rebasing and use of filter-branch was done so as to preserve the history from `dask-ndfilters` with updates to the xrefs and such. Renaming of modules was done where needed.

This likely will require more tweaking, but this is a solid base to start with as we wrap morphological operators for use with this library.