### PR TITLE
Refine _utils

### DIFF
--- a/dask_ndmorph/_utils.py
+++ b/dask_ndmorph/_utils.py
@@ -210,6 +210,29 @@ def _get_footprint(ndim, size=None, footprint=None):
     return footprint
 
 
+def _get_structure(input, structure):
+    # Create square connectivity as default
+    if structure is None:
+        structure = numpy.zeros(input.ndim * (3,), dtype=bool)
+        for i in irange(structure.ndim):
+            s = structure.ndim * [slice(None)]
+            s[i] = 1
+            s = tuple(s)
+
+            structure[s] = True
+    elif isinstance(structure, (numpy.ndarray, dask.array.Array)):
+        if structure.ndim != input.ndim:
+            raise RuntimeError(
+                "`structure` must have the same rank as `input`."
+            )
+        if not issubclass(structure.dtype.type, numpy.bool8):
+            structure = (structure != 0)
+    else:
+        raise TypeError("`structure` must be an array.")
+
+    return structure
+
+
 def _get_dtype(a):
     # Get the dtype of a value or an array.
     # Even handle non-NumPy types.

--- a/dask_ndmorph/_utils.py
+++ b/dask_ndmorph/_utils.py
@@ -233,6 +233,17 @@ def _get_structure(input, structure):
     return structure
 
 
+def _get_iterations(iterations):
+    if not isinstance(iterations, numbers.Integral):
+        raise TypeError("`iterations` must be of integral type.")
+    if iterations < 1:
+        raise NotImplementedError(
+            "`iterations` must be equal to 1 or greater not less."
+        )
+
+    return iterations
+
+
 def _get_dtype(a):
     # Get the dtype of a value or an array.
     # Even handle non-NumPy types.

--- a/dask_ndmorph/_utils.py
+++ b/dask_ndmorph/_utils.py
@@ -206,3 +206,9 @@ def _get_footprint(ndim, size=None, footprint=None):
     footprint = (footprint != 0)
 
     return footprint
+
+
+def _get_dtype(a):
+    # Get the dtype of a value or an array.
+    # Even handle non-NumPy types.
+    return getattr(a, "dtype", numpy.dtype(type(a)))

--- a/dask_ndmorph/_utils.py
+++ b/dask_ndmorph/_utils.py
@@ -268,6 +268,15 @@ def _get_mask(input, mask):
     return mask
 
 
+def _get_border_value(border_value):
+    if not isinstance(border_value, numbers.Integral):
+        raise TypeError("`border_value` must be of integral type.")
+
+    border_value = (border_value != 0)
+
+    return border_value
+
+
 def _get_brute_force(brute_force):
     if brute_force is not False:
         if brute_force is True:

--- a/dask_ndmorph/_utils.py
+++ b/dask_ndmorph/_utils.py
@@ -8,6 +8,8 @@ import re
 
 import numpy
 
+import dask.array
+
 
 try:
     from itertools import imap, izip
@@ -212,3 +214,21 @@ def _get_dtype(a):
     # Get the dtype of a value or an array.
     # Even handle non-NumPy types.
     return getattr(a, "dtype", numpy.dtype(type(a)))
+
+
+def _get_mask(input, mask):
+    if mask is None:
+        mask = True
+
+    mask_type = _get_dtype(mask).type
+    if isinstance(mask, (numpy.ndarray, dask.array.Array)):
+        if mask.shape != input.shape:
+            raise RuntimeError("`mask` must have the same shape as `input`.")
+        if not issubclass(mask_type, numpy.bool8):
+            mask = (mask != 0)
+    elif issubclass(mask_type, numpy.bool8):
+        mask = bool(mask)
+    else:
+        raise TypeError("`mask` must be a Boolean or an array.")
+
+    return mask

--- a/dask_ndmorph/_utils.py
+++ b/dask_ndmorph/_utils.py
@@ -255,3 +255,17 @@ def _get_mask(input, mask):
         raise TypeError("`mask` must be a Boolean or an array.")
 
     return mask
+
+
+def _get_brute_force(brute_force):
+    if brute_force is not False:
+        if brute_force is True:
+            raise NotImplementedError(
+                "`brute_force` other than `False` is not yet supported."
+            )
+        else:
+            raise TypeError(
+                "`brute_force` must be `bool`."
+            )
+
+    return brute_force

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -155,6 +155,18 @@ def test_errs__get_structure(err_type, input, structure):
 
 
 @pytest.mark.parametrize(
+    "err_type, iterations",
+    [
+        (TypeError, 0.0),
+        (NotImplementedError, 0),
+    ]
+)
+def test_errs__get_iterations(err_type, iterations):
+    with pytest.raises(err_type):
+        _utils._get_iterations(iterations)
+
+
+@pytest.mark.parametrize(
     "err_type, input, mask",
     [
         (
@@ -272,6 +284,17 @@ def test__get_structure(expected, input, structure):
 
     assert expected.dtype.type == result.dtype.type
     assert numpy.array((expected == result).all())[()]
+
+
+@pytest.mark.parametrize(
+    "expected, iterations",
+    [
+        (1, 1),
+        (4, 4),
+    ]
+)
+def test__get_iterations(expected, iterations):
+    assert expected == _utils._get_iterations(iterations)
 
 
 @pytest.mark.parametrize(

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -192,3 +192,18 @@ def test__get_depth(expected, size, origin):
 )
 def test__get_footprint(expected, ndim, size, footprint):
     assert (expected == _utils._get_footprint(ndim, size, footprint)).all()
+
+
+@pytest.mark.parametrize(
+    "expected, a",
+    [
+        (numpy.bool8, False),
+        (numpy.int64, 2),
+        (numpy.float64, 3.1),
+        (numpy.complex128, 1 + 2j),
+        (numpy.int16, numpy.int16(6)),
+        (numpy.uint32, numpy.arange(3, dtype=numpy.uint32)),
+    ]
+)
+def test__get_dtype(expected, a):
+    assert expected == _utils._get_dtype(a)

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -187,6 +187,18 @@ def test_errs__get_mask(err_type, input, mask):
 
 
 @pytest.mark.parametrize(
+    "err_type, border_value",
+    [
+        (TypeError, 0.0),
+        (TypeError, 1.0),
+    ]
+)
+def test_errs__get_border_value(err_type, border_value):
+    with pytest.raises(err_type):
+        _utils._get_border_value(border_value)
+
+
+@pytest.mark.parametrize(
     "err_type, brute_force",
     [
         (NotImplementedError, True),
@@ -349,6 +361,21 @@ def test__get_mask(expected, input, mask):
         assert numpy.array((expected == result).all())[()]
     else:
         assert expected == result
+
+
+@pytest.mark.parametrize(
+    "expected, border_value",
+    [
+        (False, False),
+        (True, True),
+        (False, 0),
+        (True, 1),
+        (True, 5),
+        (True, -2),
+    ]
+)
+def test__get_border_value(expected, border_value):
+    assert expected == _utils._get_border_value(border_value)
 
 
 @pytest.mark.parametrize(

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -135,6 +135,26 @@ def test_errs__get_footprint(err_type, ndim, size, footprint):
 
 
 @pytest.mark.parametrize(
+    "err_type, input, structure",
+    [
+        (
+            RuntimeError,
+            dask.array.ones([1, 2], dtype=bool, chunks=(1, 2,)),
+            dask.array.arange(2, dtype=bool, chunks=(2,))
+        ),
+        (
+            TypeError,
+            dask.array.arange(2, dtype=bool, chunks=(2,)),
+            2.0
+        ),
+    ]
+)
+def test_errs__get_structure(err_type, input, structure):
+    with pytest.raises(err_type):
+        _utils._get_structure(input, structure)
+
+
+@pytest.mark.parametrize(
     "err_type, input, mask",
     [
         (
@@ -213,6 +233,33 @@ def test__get_depth(expected, size, origin):
 )
 def test__get_footprint(expected, ndim, size, footprint):
     assert (expected == _utils._get_footprint(ndim, size, footprint)).all()
+
+
+@pytest.mark.parametrize(
+    "expected, input, structure",
+    [
+        (
+            numpy.array([0, 1, 0], dtype=bool),
+            (dask.array.arange(10, dtype=int, chunks=(10,)) % 2).astype(bool),
+            None
+        ),
+        (
+            numpy.array([1, 1, 1], dtype=bool),
+            (dask.array.arange(10, dtype=int, chunks=(10,)) % 2).astype(bool),
+            numpy.array([1, 1, 1], dtype=int)
+        ),
+        (
+            numpy.array([1, 1, 1], dtype=bool),
+            (dask.array.arange(10, dtype=int, chunks=(10,)) % 2).astype(bool),
+            numpy.array([1, 1, 1], dtype=bool)
+        ),
+    ]
+)
+def test__get_structure(expected, input, structure):
+    result = _utils._get_structure(input, structure)
+
+    assert expected.dtype.type == result.dtype.type
+    assert numpy.array((expected == result).all())[()]
 
 
 @pytest.mark.parametrize(

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -175,6 +175,18 @@ def test_errs__get_mask(err_type, input, mask):
 
 
 @pytest.mark.parametrize(
+    "err_type, brute_force",
+    [
+        (NotImplementedError, True),
+        (TypeError, 1),
+    ]
+)
+def test_errs__get_brute_force(err_type, brute_force):
+    with pytest.raises(err_type):
+        _utils._get_brute_force(brute_force)
+
+
+@pytest.mark.parametrize(
     "expected, ndim, depth, boundary",
     [
         (({0: 0}, {0: "reflect"}), 1, 0, "none"),
@@ -314,3 +326,13 @@ def test__get_mask(expected, input, mask):
         assert numpy.array((expected == result).all())[()]
     else:
         assert expected == result
+
+
+@pytest.mark.parametrize(
+    "expected, brute_force",
+    [
+        (False, False),
+    ]
+)
+def test__get_brute_force(expected, brute_force):
+    assert expected == _utils._get_brute_force(brute_force)


### PR DESCRIPTION
Makes various additions and refinements to the `dask_ndmorph._utils` module that are useful for morphological operators. Includes similar changes to the tests to cover these modifications.