### PR TITLE
Add _where

### DIFF
--- a/dask_ndmorph/_ops.py
+++ b/dask_ndmorph/_ops.py
@@ -1,1 +1,17 @@
 # -*- coding: utf-8 -*-
+
+
+import numpy
+
+import dask.array
+
+
+def _where(condition, x, y):
+    if isinstance(condition, (bool, numpy.bool8)):
+        dtype = numpy.promote_types(x.dtype, y.dtype)
+        if condition:
+            return x.astype(dtype)
+        else:
+            return y.astype(dtype)
+    else:
+        return dask.array.where(condition, x, y)

--- a/tests/test__ops.py
+++ b/tests/test__ops.py
@@ -4,4 +4,69 @@
 from __future__ import absolute_import
 
 
+import pytest
+
+import numpy
+
+import dask.array
+
 from dask_ndmorph import _ops
+
+
+@pytest.mark.parametrize(
+    "condition, x, y",
+    [
+        (
+            True,
+            dask.array.arange(2, chunks=(2,)),
+            dask.array.arange(2, 4, chunks=(2,))
+        ),
+        (
+            False,
+            dask.array.arange(2, chunks=(2,)),
+            dask.array.arange(2, 4, chunks=(2,))
+        ),
+        (
+            True,
+            dask.array.arange(2, chunks=(2,)),
+            dask.array.arange(2, 4, dtype=float, chunks=(2,))
+        ),
+        (
+            False,
+            dask.array.arange(2, dtype=float, chunks=(2,)),
+            dask.array.arange(2, 4, chunks=(2,))
+        ),
+        (
+            numpy.bool8(True),
+            dask.array.arange(2, chunks=(2,)),
+            dask.array.arange(2, 4, chunks=(2,))
+        ),
+        (
+            numpy.bool8(False),
+            dask.array.arange(2, chunks=(2,)),
+            dask.array.arange(2, 4, chunks=(2,))
+        ),
+        (
+            dask.array.arange(2, dtype=bool, chunks=(2,)),
+            dask.array.arange(2, chunks=(2,)),
+            dask.array.arange(2, 4, chunks=(2,))
+        ),
+    ]
+)
+def test__where(condition, x, y):
+    dask_result = dask.array.where(condition, x, y)
+
+    result = _ops._where(condition, x, y)
+
+    assert result.dtype.type == dask_result.dtype.type
+    assert numpy.array((result == dask_result).all())[()]
+
+    if isinstance(condition, (bool, numpy.bool8)):
+        dtype = numpy.promote_types(x.dtype, y.dtype)
+        if condition:
+            return x.astype(dtype)
+        else:
+            return y.astype(dtype)
+
+        assert numpy.array((result == expected).all())[()]
+        assert result is expected


### PR DESCRIPTION
Adds an optimized version Dask Array's `where`, which avoids adding additional nodes to the graph if the condition is a straight Boolean value. However, if the condition is an Array, it goes through the usual procedure. Should also add that the result type will be promoted based on the two inputs even if the `where` operation is optimized out. This is consistent with NumPy's and Dask's current behavior in this regard.

Note: This will be unnecessary if Dask takes on this optimization. ( https://github.com/dask/dask/issues/2407 )