### PR TITLE
Use SciPy's generate_binary_structure

### DIFF
--- a/dask_ndmorph/_utils.py
+++ b/dask_ndmorph/_utils.py
@@ -7,6 +7,7 @@ import numbers
 import re
 
 import numpy
+import scipy.ndimage
 
 import dask.array
 
@@ -213,13 +214,7 @@ def _get_footprint(ndim, size=None, footprint=None):
 def _get_structure(input, structure):
     # Create square connectivity as default
     if structure is None:
-        structure = numpy.zeros(input.ndim * (3,), dtype=bool)
-        for i in irange(structure.ndim):
-            s = structure.ndim * [slice(None)]
-            s[i] = 1
-            s = tuple(s)
-
-            structure[s] = True
+        structure = scipy.ndimage.generate_binary_structure(input.ndim, 1)
     elif isinstance(structure, (numpy.ndarray, dask.array.Array)):
         if structure.ndim != input.ndim:
             raise RuntimeError(

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -280,6 +280,11 @@ def test__get_footprint(expected, ndim, size, footprint):
             None
         ),
         (
+            numpy.array([[0, 1, 0], [1, 1, 1], [0, 1, 0]], dtype=bool),
+            (dask.array.arange(100, chunks=10).reshape(10, 10) % 2).astype(bool),
+            None
+        ),
+        (
             numpy.array([1, 1, 1], dtype=bool),
             (dask.array.arange(10, chunks=(10,)) % 2).astype(bool),
             numpy.array([1, 1, 1], dtype=int)

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -275,7 +275,7 @@ def test__get_footprint(expected, ndim, size, footprint):
     "expected, input, structure",
     [
         (
-            numpy.array([0, 1, 0], dtype=bool),
+            numpy.array([1, 1, 1], dtype=bool),
             (dask.array.arange(10, chunks=(10,)) % 2).astype(bool),
             None
         ),

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -276,17 +276,17 @@ def test__get_footprint(expected, ndim, size, footprint):
     [
         (
             numpy.array([0, 1, 0], dtype=bool),
-            (dask.array.arange(10, dtype=int, chunks=(10,)) % 2).astype(bool),
+            (dask.array.arange(10, chunks=(10,)) % 2).astype(bool),
             None
         ),
         (
             numpy.array([1, 1, 1], dtype=bool),
-            (dask.array.arange(10, dtype=int, chunks=(10,)) % 2).astype(bool),
+            (dask.array.arange(10, chunks=(10,)) % 2).astype(bool),
             numpy.array([1, 1, 1], dtype=int)
         ),
         (
             numpy.array([1, 1, 1], dtype=bool),
-            (dask.array.arange(10, dtype=int, chunks=(10,)) % 2).astype(bool),
+            (dask.array.arange(10, chunks=(10,)) % 2).astype(bool),
             numpy.array([1, 1, 1], dtype=bool)
         ),
     ]


### PR DESCRIPTION
Uses SciPy's [`generate_binary_structure`]( https://docs.scipy.org/doc/scipy-0.19.0/reference/generated/scipy.ndimage.generate_binary_structure.html ) instead of hand rolling our own. Adds a test for the 2-D default structure case. Also fixes a bug in the test of the 1-D default structure case. Did some minor cleanup in the associate test as well.