### PR TITLE
Add binary morphological operations

### DIFF
--- a/dask_ndmorph/__init__.py
+++ b/dask_ndmorph/__init__.py
@@ -6,3 +6,33 @@ __email__ = "kirkhamj@janelia.hhmi.org"
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
+
+
+import scipy.ndimage.morphology
+
+import dask_ndmorph._utils as _utils
+import dask_ndmorph._ops as _ops
+
+
+@_utils._update_wrapper(scipy.ndimage.morphology.binary_dilation)
+def binary_dilation(input,
+                    structure=None,
+                    iterations=1,
+                    mask=None,
+                    border_value=0,
+                    origin=0,
+                    brute_force=False):
+    border_value = _utils._get_border_value(border_value)
+
+    result = _ops._binary_op(
+        scipy.ndimage.morphology.binary_dilation,
+        input,
+        structure=structure,
+        iterations=iterations,
+        mask=mask,
+        origin=origin,
+        brute_force=brute_force,
+        border_value=border_value
+    )
+
+    return result

--- a/dask_ndmorph/__init__.py
+++ b/dask_ndmorph/__init__.py
@@ -82,3 +82,25 @@ def binary_erosion(input,
     )
 
     return result
+
+
+@_utils._update_wrapper(scipy.ndimage.morphology.binary_opening)
+def binary_opening(input,
+                   structure=None,
+                   iterations=1,
+                   origin=0):
+    input = (input != 0)
+
+    structure = _utils._get_structure(input, structure)
+    iterations = _utils._get_iterations(iterations)
+    origin = _utils._get_origin(structure.shape, origin)
+
+    result = input
+    result = binary_erosion(
+        result, structure=structure, iterations=iterations, origin=origin
+    )
+    result = binary_dilation(
+        result, structure=structure, iterations=iterations, origin=origin
+    )
+
+    return result

--- a/dask_ndmorph/__init__.py
+++ b/dask_ndmorph/__init__.py
@@ -36,3 +36,27 @@ def binary_dilation(input,
     )
 
     return result
+
+
+@_utils._update_wrapper(scipy.ndimage.morphology.binary_erosion)
+def binary_erosion(input,
+                   structure=None,
+                   iterations=1,
+                   mask=None,
+                   border_value=0,
+                   origin=0,
+                   brute_force=False):
+    border_value = _utils._get_border_value(border_value)
+
+    result = _ops._binary_op(
+        scipy.ndimage.morphology.binary_erosion,
+        input,
+        structure=structure,
+        iterations=iterations,
+        mask=mask,
+        origin=origin,
+        brute_force=brute_force,
+        border_value=border_value
+    )
+
+    return result

--- a/dask_ndmorph/__init__.py
+++ b/dask_ndmorph/__init__.py
@@ -14,6 +14,28 @@ import dask_ndmorph._utils as _utils
 import dask_ndmorph._ops as _ops
 
 
+@_utils._update_wrapper(scipy.ndimage.morphology.binary_closing)
+def binary_closing(input,
+                   structure=None,
+                   iterations=1,
+                   origin=0):
+    input = (input != 0)
+
+    structure = _utils._get_structure(input, structure)
+    iterations = _utils._get_iterations(iterations)
+    origin = _utils._get_origin(structure.shape, origin)
+
+    result = input
+    result = binary_dilation(
+        result, structure=structure, iterations=iterations, origin=origin
+    )
+    result = binary_erosion(
+        result, structure=structure, iterations=iterations, origin=origin
+    )
+
+    return result
+
+
 @_utils._update_wrapper(scipy.ndimage.morphology.binary_dilation)
 def binary_dilation(input,
                     structure=None,

--- a/dask_ndmorph/_ops.py
+++ b/dask_ndmorph/_ops.py
@@ -5,6 +5,14 @@ import numpy
 
 import dask.array
 
+import dask_ndmorph._utils as _utils
+
+
+try:
+    irange = xrange
+except NameError:
+    irange = range
+
 
 def _where(condition, x, y):
     if isinstance(condition, (bool, numpy.bool8)):
@@ -15,3 +23,37 @@ def _where(condition, x, y):
             return y.astype(dtype)
     else:
         return dask.array.where(condition, x, y)
+
+
+def _binary_op(func,
+               input,
+               structure=None,
+               iterations=1,
+               mask=None,
+               origin=0,
+               brute_force=False,
+               **kwargs):
+    input = (input != 0)
+
+    structure = _utils._get_structure(input, structure)
+    iterations = _utils._get_iterations(iterations)
+    mask = _utils._get_mask(input, mask)
+    origin = _utils._get_origin(structure.shape, origin)
+    brute_force = _utils._get_brute_force(brute_force)
+    depth = _utils._get_depth(structure.shape, origin)
+    depth, boundary = _utils._get_depth_boundary(structure.ndim, depth, "none")
+
+    result = input
+    for i in irange(iterations):
+        iter_result = result.map_overlap(
+            func,
+            depth=depth,
+            boundary=boundary,
+            dtype=bool,
+            structure=structure,
+            origin=origin,
+            **kwargs
+        )
+        result = dask.array.where(mask, iter_result, result)
+
+    return result

--- a/dask_ndmorph/_ops.py
+++ b/dask_ndmorph/_ops.py
@@ -54,6 +54,6 @@ def _binary_op(func,
             origin=origin,
             **kwargs
         )
-        result = dask.array.where(mask, iter_result, result)
+        result = _where(mask, iter_result, result)
 
     return result

--- a/tests/test_dask_ndmorph.py
+++ b/tests/test_dask_ndmorph.py
@@ -5,9 +5,498 @@ from __future__ import absolute_import
 
 import pytest
 
+import numpy as np
+import scipy.ndimage as spnd
 
-def test_import_toplevel():
-    try:
-        import dask_ndmorph
-    except ImportError:
-        pytest.fail("Unable to import `dask_ndmorph`.")
+import dask.array as da
+import dask.array.utils as dau
+import dask_ndmorph as da_ndm
+
+
+@pytest.mark.parametrize(
+    "funcname",
+    [
+        "binary_dilation",
+    ]
+)
+@pytest.mark.parametrize(
+    "err_type, input, structure, origin",
+    [
+        (
+            RuntimeError,
+            da.ones([1, 2], dtype=bool, chunks=(1, 2,)),
+            da.arange(2, dtype=bool, chunks=(2,)),
+            0
+        ),
+        (
+            TypeError,
+            da.arange(2, dtype=bool, chunks=(2,)),
+            2.0,
+            0
+        ),
+        (
+            TypeError,
+            da.ones([2], dtype=bool, chunks=(2,)),
+            da.arange(2, dtype=bool, chunks=(2,)),
+            0.0
+        ),
+    ]
+)
+def test_errs_binary_ops(funcname,
+                         err_type,
+                         input,
+                         structure,
+                         origin):
+    da_func = getattr(da_ndm, funcname)
+
+    with pytest.raises(err_type):
+        da_func(
+            input,
+            structure=structure,
+            origin=origin
+        )
+
+
+@pytest.mark.parametrize(
+    "funcname",
+    [
+        "binary_dilation",
+    ]
+)
+@pytest.mark.parametrize(
+    "err_type, input, structure, iterations, origin",
+    [
+        (
+            TypeError,
+            da.ones([2], dtype=bool, chunks=(2,)),
+            da.arange(2, dtype=bool, chunks=(2,)),
+            1.0,
+            0
+        ),
+        (
+            NotImplementedError,
+            da.ones([2], dtype=bool, chunks=(2,)),
+            da.arange(2, dtype=bool, chunks=(2,)),
+            0,
+            0
+        )
+    ]
+)
+def test_errs_binary_ops_iter(funcname,
+                              err_type,
+                              input,
+                              structure,
+                              iterations,
+                              origin):
+    da_func = getattr(da_ndm, funcname)
+
+    with pytest.raises(err_type):
+        da_func(
+            input,
+            structure=structure,
+            iterations=iterations,
+            origin=origin
+        )
+
+
+@pytest.mark.parametrize(
+    "funcname",
+    [
+        "binary_dilation",
+    ]
+)
+@pytest.mark.parametrize(
+    "err_type, input, structure, iterations, mask, border_value, origin"
+    ", brute_force",
+    [
+        (
+            RuntimeError,
+            da.ones([2], dtype=bool, chunks=(2,)),
+            da.arange(2, dtype=bool, chunks=(2,)),
+            1,
+            da.arange(2, dtype=bool, chunks=(2,))[None],
+            0,
+            0,
+            False
+        ),
+        (
+            TypeError,
+            da.ones([2], dtype=bool, chunks=(2,)),
+            da.arange(2, dtype=bool, chunks=(2,)),
+            1,
+            da.arange(2, dtype=bool, chunks=(2,)),
+            2.0,
+            0,
+            False
+        ),
+        (
+            NotImplementedError,
+            da.ones([2], dtype=bool, chunks=(2,)),
+            da.arange(2, dtype=bool, chunks=(2,)),
+            1,
+            da.arange(2, dtype=bool, chunks=(2,)),
+            0,
+            0,
+            True
+        ),
+    ]
+)
+def test_errs_binary_ops_expanded(funcname,
+                                  err_type,
+                                  input,
+                                  structure,
+                                  iterations,
+                                  mask,
+                                  border_value,
+                                  origin,
+                                  brute_force):
+    da_func = getattr(da_ndm, funcname)
+
+    with pytest.raises(err_type):
+        da_func(
+            input,
+            structure=structure,
+            iterations=iterations,
+            mask=mask,
+            border_value=border_value,
+            origin=origin,
+            brute_force=brute_force
+        )
+
+
+@pytest.mark.parametrize(
+    "funcname",
+    [
+        "binary_dilation",
+    ]
+)
+@pytest.mark.parametrize(
+    "input, structure, origin",
+    [
+        (
+            da.from_array(
+                np.array(
+                    [[0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0],
+                     [1, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0],
+                     [0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 1, 1],
+                     [1, 1, 0, 0, 0, 1, 1, 1, 0, 1, 0, 1],
+                     [1, 1, 0, 1, 1, 1, 0, 1, 0, 1, 0, 0],
+                     [0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 1, 0],
+                     [0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 1, 1],
+                     [0, 1, 0, 1, 0, 1, 0, 0, 1, 0, 0, 0],
+                     [1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0],
+                     [0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0]],
+                    dtype=bool
+                ),
+                chunks=(5, 6)
+            ),
+            None,
+            0
+        ),
+        (
+            da.from_array(
+                np.array(
+                    [[0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0],
+                     [1, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0],
+                     [0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 1, 1],
+                     [1, 1, 0, 0, 0, 1, 1, 1, 0, 1, 0, 1],
+                     [1, 1, 0, 1, 1, 1, 0, 1, 0, 1, 0, 0],
+                     [0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 1, 0],
+                     [0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 1, 1],
+                     [0, 1, 0, 1, 0, 1, 0, 0, 1, 0, 0, 0],
+                     [1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0],
+                     [0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0]],
+                    dtype=bool
+                ),
+                chunks=(5, 6)
+            ),
+            np.ones([3, 3], dtype=bool),
+            0
+        ),
+        (
+            da.from_array(
+                np.array(
+                    [[0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0],
+                     [1, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0],
+                     [0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 1, 1],
+                     [1, 1, 0, 0, 0, 1, 1, 1, 0, 1, 0, 1],
+                     [1, 1, 0, 1, 1, 1, 0, 1, 0, 1, 0, 0],
+                     [0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 1, 0],
+                     [0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 1, 1],
+                     [0, 1, 0, 1, 0, 1, 0, 0, 1, 0, 0, 0],
+                     [1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0],
+                     [0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0]],
+                    dtype=bool
+                ),
+                chunks=(5, 6)
+            ),
+            np.ones([3, 3], dtype=bool),
+            1
+        ),
+        (
+            da.from_array(
+                np.array(
+                    [[0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0],
+                     [1, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0],
+                     [0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 1, 1],
+                     [1, 1, 0, 0, 0, 1, 1, 1, 0, 1, 0, 1],
+                     [1, 1, 0, 1, 1, 1, 0, 1, 0, 1, 0, 0],
+                     [0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 1, 0],
+                     [0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 1, 1],
+                     [0, 1, 0, 1, 0, 1, 0, 0, 1, 0, 0, 0],
+                     [1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0],
+                     [0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0]],
+                    dtype=bool
+                ),
+                chunks=(5, 6)
+            ),
+            np.ones([3, 3], dtype=bool),
+            -1
+        ),
+    ]
+)
+def test_binary_ops(funcname,
+                    input,
+                    structure,
+                    origin):
+    da_func = getattr(da_ndm, funcname)
+    sp_func = getattr(spnd, funcname)
+
+    da_result = da_func(
+        input,
+        structure=structure,
+        origin=origin
+    )
+
+    sp_result = sp_func(
+        input,
+        structure=structure,
+        origin=origin
+    )
+
+    dau.assert_eq(sp_result, da_result)
+
+
+@pytest.mark.parametrize(
+    "funcname",
+    [
+        "binary_dilation",
+    ]
+)
+@pytest.mark.parametrize(
+    "input, structure, iterations, origin",
+    [
+        (
+            da.from_array(
+                np.array(
+                    [[0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0],
+                     [1, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0],
+                     [0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 1, 1],
+                     [1, 1, 0, 0, 0, 1, 1, 1, 0, 1, 0, 1],
+                     [1, 1, 0, 1, 1, 1, 0, 1, 0, 1, 0, 0],
+                     [0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 1, 0],
+                     [0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 1, 1],
+                     [0, 1, 0, 1, 0, 1, 0, 0, 1, 0, 0, 0],
+                     [1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0],
+                     [0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0]],
+                    dtype=bool
+                ),
+                chunks=(5, 6)
+            ),
+            np.ones([3, 3], dtype=bool),
+            3,
+            0
+        ),
+        (
+            da.from_array(
+                np.array(
+                    [[0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0],
+                     [1, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0],
+                     [0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 1, 1],
+                     [1, 1, 0, 0, 0, 1, 1, 1, 0, 1, 0, 1],
+                     [1, 1, 0, 1, 1, 1, 0, 1, 0, 1, 0, 0],
+                     [0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 1, 0],
+                     [0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 1, 1],
+                     [0, 1, 0, 1, 0, 1, 0, 0, 1, 0, 0, 0],
+                     [1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0],
+                     [0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0]],
+                    dtype=bool
+                ),
+                chunks=(5, 6)
+            ),
+            np.ones([3, 3], dtype=bool),
+            3,
+            1
+        ),
+    ]
+)
+def test_binary_ops_iter(funcname,
+                         input,
+                         structure,
+                         iterations,
+                         origin):
+    da_func = getattr(da_ndm, funcname)
+    sp_func = getattr(spnd, funcname)
+
+    da_result = da_func(
+        input,
+        structure=structure,
+        iterations=iterations,
+        origin=origin
+    )
+
+    sp_result = sp_func(
+        input,
+        structure=structure,
+        iterations=iterations,
+        origin=origin
+    )
+
+    dau.assert_eq(sp_result, da_result)
+
+
+@pytest.mark.parametrize(
+    "funcname",
+    [
+        "binary_dilation",
+    ]
+)
+@pytest.mark.parametrize(
+    "input, structure, iterations, mask, border_value, origin, brute_force",
+    [
+        (
+            da.from_array(
+                np.array(
+                    [[0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0],
+                     [1, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0],
+                     [0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 1, 1],
+                     [1, 1, 0, 0, 0, 1, 1, 1, 0, 1, 0, 1],
+                     [1, 1, 0, 1, 1, 1, 0, 1, 0, 1, 0, 0],
+                     [0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 1, 0],
+                     [0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 1, 1],
+                     [0, 1, 0, 1, 0, 1, 0, 0, 1, 0, 0, 0],
+                     [1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0],
+                     [0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0]],
+                    dtype=bool
+                ),
+                chunks=(5, 6)
+            ),
+            np.ones([3, 3], dtype=bool),
+            1,
+            None,
+            1,
+            0,
+            False
+        ),
+        (
+            da.from_array(
+                np.array(
+                    [[0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0],
+                     [1, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0],
+                     [0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 1, 1],
+                     [1, 1, 0, 0, 0, 1, 1, 1, 0, 1, 0, 1],
+                     [1, 1, 0, 1, 1, 1, 0, 1, 0, 1, 0, 0],
+                     [0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 1, 0],
+                     [0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 1, 1],
+                     [0, 1, 0, 1, 0, 1, 0, 0, 1, 0, 0, 0],
+                     [1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0],
+                     [0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0]],
+                    dtype=bool
+                ),
+                chunks=(5, 6)
+            ),
+            np.ones([3, 3], dtype=bool),
+            1,
+            da.from_array(
+                np.array(
+                    [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                     [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                     [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                     [0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0],
+                     [0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0],
+                     [0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0],
+                     [0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0],
+                     [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                     [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                     [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]],
+                    dtype=bool
+                ),
+                chunks=(5, 6)
+            ),
+            0,
+            0,
+            False
+        ),
+        (
+            da.from_array(
+                np.array(
+                    [[0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0],
+                     [1, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0],
+                     [0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 1, 1],
+                     [1, 1, 0, 0, 0, 1, 1, 1, 0, 1, 0, 1],
+                     [1, 1, 0, 1, 1, 1, 0, 1, 0, 1, 0, 0],
+                     [0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 1, 0],
+                     [0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 1, 1],
+                     [0, 1, 0, 1, 0, 1, 0, 0, 1, 0, 0, 0],
+                     [1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0],
+                     [0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0]],
+                    dtype=bool
+                ),
+                chunks=(5, 6)
+            ),
+            np.ones([3, 3], dtype=bool),
+            3,
+            da.from_array(
+                np.array(
+                    [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                     [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                     [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                     [0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0],
+                     [0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0],
+                     [0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0],
+                     [0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0],
+                     [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                     [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                     [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]],
+                    dtype=bool
+                ),
+                chunks=(5, 6)
+            ),
+            0,
+            0,
+            False
+        ),
+    ]
+)
+def test_binary_ops_expanded(funcname,
+                             input,
+                             structure,
+                             iterations,
+                             mask,
+                             border_value,
+                             origin,
+                             brute_force):
+    da_func = getattr(da_ndm, funcname)
+    sp_func = getattr(spnd, funcname)
+
+    da_result = da_func(
+        input,
+        structure=structure,
+        iterations=iterations,
+        mask=mask,
+        border_value=border_value,
+        origin=origin,
+        brute_force=brute_force
+    )
+
+    sp_result = sp_func(
+        input,
+        structure=structure,
+        iterations=iterations,
+        mask=mask,
+        border_value=border_value,
+        origin=origin,
+        brute_force=brute_force
+    )
+
+    dau.assert_eq(sp_result, da_result)

--- a/tests/test_dask_ndmorph.py
+++ b/tests/test_dask_ndmorph.py
@@ -16,6 +16,7 @@ import dask_ndmorph as da_ndm
 @pytest.mark.parametrize(
     "funcname",
     [
+        "binary_closing",
         "binary_dilation",
         "binary_erosion",
     ]
@@ -61,6 +62,7 @@ def test_errs_binary_ops(funcname,
 @pytest.mark.parametrize(
     "funcname",
     [
+        "binary_closing",
         "binary_dilation",
         "binary_erosion",
     ]
@@ -170,6 +172,7 @@ def test_errs_binary_ops_expanded(funcname,
 @pytest.mark.parametrize(
     "funcname",
     [
+        "binary_closing",
         "binary_dilation",
         "binary_erosion",
     ]
@@ -284,6 +287,7 @@ def test_binary_ops(funcname,
 @pytest.mark.parametrize(
     "funcname",
     [
+        "binary_closing",
         "binary_dilation",
         "binary_erosion",
     ]

--- a/tests/test_dask_ndmorph.py
+++ b/tests/test_dask_ndmorph.py
@@ -19,6 +19,7 @@ import dask_ndmorph as da_ndm
         "binary_closing",
         "binary_dilation",
         "binary_erosion",
+        "binary_opening",
     ]
 )
 @pytest.mark.parametrize(
@@ -65,6 +66,7 @@ def test_errs_binary_ops(funcname,
         "binary_closing",
         "binary_dilation",
         "binary_erosion",
+        "binary_opening",
     ]
 )
 @pytest.mark.parametrize(
@@ -175,6 +177,7 @@ def test_errs_binary_ops_expanded(funcname,
         "binary_closing",
         "binary_dilation",
         "binary_erosion",
+        "binary_opening",
     ]
 )
 @pytest.mark.parametrize(
@@ -290,6 +293,7 @@ def test_binary_ops(funcname,
         "binary_closing",
         "binary_dilation",
         "binary_erosion",
+        "binary_opening",
     ]
 )
 @pytest.mark.parametrize(

--- a/tests/test_dask_ndmorph.py
+++ b/tests/test_dask_ndmorph.py
@@ -17,6 +17,7 @@ import dask_ndmorph as da_ndm
     "funcname",
     [
         "binary_dilation",
+        "binary_erosion",
     ]
 )
 @pytest.mark.parametrize(
@@ -61,6 +62,7 @@ def test_errs_binary_ops(funcname,
     "funcname",
     [
         "binary_dilation",
+        "binary_erosion",
     ]
 )
 @pytest.mark.parametrize(
@@ -103,6 +105,7 @@ def test_errs_binary_ops_iter(funcname,
     "funcname",
     [
         "binary_dilation",
+        "binary_erosion",
     ]
 )
 @pytest.mark.parametrize(
@@ -168,6 +171,7 @@ def test_errs_binary_ops_expanded(funcname,
     "funcname",
     [
         "binary_dilation",
+        "binary_erosion",
     ]
 )
 @pytest.mark.parametrize(
@@ -281,6 +285,7 @@ def test_binary_ops(funcname,
     "funcname",
     [
         "binary_dilation",
+        "binary_erosion",
     ]
 )
 @pytest.mark.parametrize(
@@ -359,6 +364,7 @@ def test_binary_ops_iter(funcname,
     "funcname",
     [
         "binary_dilation",
+        "binary_erosion",
     ]
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
Partially addresses issue ( https://github.com/dask-image/dask-ndmorph/issues/12 ).

Adds implementations of [`binary_closing`]( https://docs.scipy.org/doc/scipy-0.19.0/reference/generated/scipy.ndimage.binary_closing.html ), [`binary_dilation`]( https://docs.scipy.org/doc/scipy-0.19.0/reference/generated/scipy.ndimage.binary_dilation.html ), [`binary_erosion`]( https://docs.scipy.org/doc/scipy-0.19.0/reference/generated/scipy.ndimage.binary_erosion.html ), and [`binary_opening`]( https://docs.scipy.org/doc/scipy-0.19.0/reference/generated/scipy.ndimage.binary_opening.html ) for Dask Arrays. Creates these implementations through a mixture of wrapping the underlying SciPy functions, implementing some functionality with Dask Arrays directly, composing operations to get other operations, and so on. Tests all of them against their SciPy counterparts on small test data to make sure they work correctly.