### PR TITLE
Correct description in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ cmdclasses.update(versioneer.get_cmdclass())
 setup(
     name="dask-ndmorph",
     version=versioneer.get_version(),
-    description="A library for using N-D filters with Dask Arrays",
+    description="A library of N-D morphological operations for Dask Arrays",
     long_description=readme,
     author="John Kirkham",
     author_email="kirkhamj@janelia.hhmi.org",


### PR DESCRIPTION
Was incorrectly borrowing the description from `dask-ndfilters` and using it to describe this library, `dask-ndmorph`. Have now corrected that by noting these are morphological operations for use with Dask Arrays.