### PR TITLE
Use `int_` instead of `int64`

### DIFF
--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -318,7 +318,7 @@ def test__get_iterations(expected, iterations):
     "expected, a",
     [
         (numpy.bool8, False),
-        (numpy.int64, 2),
+        (numpy.int_, 2),
         (numpy.float64, 3.1),
         (numpy.complex128, 1 + 2j),
         (numpy.int16, numpy.int16(6)),


### PR DESCRIPTION
On Windows, the default integer is 32-bit. So we shouldn't assume that a default integer will be cast to NumPy's `int64`. Instead we make use of NumPy's `int_`, which may be 32-bit or 64-bit depending on the platform. This should resolve the test issue on Windows.